### PR TITLE
support for ads1015 chipset 

### DIFF
--- a/lib/ads1015.ex
+++ b/lib/ads1015.ex
@@ -1,10 +1,10 @@
 defmodule ADS1015 do
   @moduledoc """
-  Functions to interact with an ADS1115 analog-to-digital chip
+  Functions to interact with an ADS1015 analog-to-digital chip
   """
 
   alias Circuits.I2C
-  alias ADS1115.Config
+  alias ADS1015.Config
 
   @config_register <<1>>
   @sensor_register <<0>>

--- a/lib/ads1015.ex
+++ b/lib/ads1015.ex
@@ -1,0 +1,73 @@
+defmodule ADS1015 do
+  @moduledoc """
+  Functions to interact with an ADS1115 analog-to-digital chip
+  """
+
+  alias Circuits.I2C
+  alias ADS1115.Config
+
+  @config_register <<1>>
+  @sensor_register <<0>>
+
+  @doc "Read the current configuration from the device"
+  @spec config(reference(), byte()) :: {:ok, Config.t()} | {:error, term()}
+  def config(bus, addr) do
+    case I2C.write_read(bus, addr, @config_register, 2) do
+      {:ok, bytes} -> {:ok, Config.decode(bytes)}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @doc "Set the configuration on the device"
+  @spec set_config(reference(), I2C.address(), Config.t()) :: :ok | {:error, term()}
+  def set_config(bus, addr, %Config{}=config) do
+    bytes = @config_register <> Config.encode(config)
+    I2C.write(bus, addr, bytes)
+  end
+
+  @doc "Ask for a reading for one of the analog signals with default settings"
+  @spec read(reference(), byte(), Config.comparison(), Config.gain()) ::
+          {:ok, integer()} | {:error, term()}
+  def read(bus, addr, comparison, gain \\ 2048) do
+    config = %Config{
+      performing_conversion: false,
+      mode: :single_shot,
+      mux: comparison,
+      gain: gain
+    }
+
+    custom_read(bus, addr, config)
+  end
+
+ @doc """
+  Ask for a reading of an analog signal with customizable comparison parameters.
+
+  This will write the configuration register, then wait for the reading to be ready and read it back.
+  Make sure to set `performing_conversion: false` and `mode: :single_shot` so that the chip will know
+  we are waiting for a reading.
+
+  ADS1015 uses 16bit register but it has a 12bit value.
+  """
+  @spec custom_read(reference(), I2C.address(), Config.t()) :: {:ok, integer()} | {:error, term()}
+  def custom_read(bus, addr, %Config{}=config) do
+    with :ok <- set_config(bus, addr, config),
+         :ok <- wait_for_reading(bus, addr),
+         {:ok, <<val::signed-size(16)>>} <- I2C.write_read(bus, addr, @sensor_register, 2) do
+
+           val = val / 16 # equivalent to val >> 4
+           if val > 2047 do   # 0x7FF
+             {:ok, val - 4096}  # double 2048
+           else
+             {:ok, val}
+           end
+    end
+  end
+
+  defp wait_for_reading(bus, addr), do: wait_for_reading(bus, addr, config(bus, addr))
+  defp wait_for_reading(_bus, _addr, {:error, reason}), do: {:error, reason}
+  defp wait_for_reading(_bus, _addr, {:ok, %Config{performing_conversion: false}}), do: :ok
+
+  defp wait_for_reading(bus, addr, _config) do
+    wait_for_reading(bus, addr, config(bus, addr))
+  end
+end

--- a/lib/ads1015/config.ex
+++ b/lib/ads1015/config.ex
@@ -1,0 +1,150 @@
+defmodule ADS1015.Config do
+  @moduledoc """
+  A struct representing the configuration of an ADS1115 chip.
+
+  This module handles decoding the 2-byte binary representation of the register
+  into a struct and also encoding a struct back into the 2-byte binary representation.
+  For details about what the various configuration options mean, please see
+  [the datasheet](http://www.ti.com/lit/gpn/ads1115).
+  """
+
+  @type comp_mode :: :traditional | :window
+  @type comp_polarity :: :active_low | :active_high
+  @type comp_queue :: 1 | 2 | 3 | :disabled
+  @type comparison ::
+          {:ain0, :ain1 | :ain3 | :gnd}
+          | {:ain1, :ain3 | :gnd}
+          | {:ain2, :ain3 | :gnd}
+          | {:ain3, :gnd}
+  @type data_rate :: 128 | 250 | 490 | 920 | 1600 | 2400 | 3300 | 3300
+  @type gain :: 256 | 512 | 1024 | 2048 | 4096 | 6144
+  @type mode :: :continuous | :single_shot
+  @type t :: %__MODULE__{
+          performing_conversion: true | false,
+          mux: comparison,
+          gain: gain,
+          mode: mode,
+          data_rate: data_rate,
+          comp_mode: comp_mode,
+          comp_polarity: comp_polarity,
+          comp_latch: true | false,
+          comp_queue: comp_queue
+        }
+  defstruct performing_conversion: false,
+            mux: {:ain0, :ain1},  #default
+            gain: 2048, # default
+            mode: :single_shot,
+            data_rate: 1600,  # default
+            comp_mode: :traditional,
+            comp_polarity: :active_low,
+            comp_latch: false,
+            comp_queue: :disabled
+
+  @spec encode(ADS1015.Config.t()) :: <<_::16>>
+  def encode(%__MODULE__{} = config) do
+    <<
+      encode_performing_conversion(config.performing_conversion)::size(1),
+      encode_mux(config.mux)::size(3),
+      encode_gain(config.gain)::size(3),
+      encode_mode(config.mode)::size(1),
+      encode_data_rate(config.data_rate)::size(3),
+      encode_comp_mode(config.comp_mode)::size(1),
+      encode_comp_polarity(config.comp_polarity)::size(1),
+      encode_comp_latch(config.comp_latch)::size(1),
+      encode_comp_queue(config.comp_queue)::size(2)
+    >>
+  end
+
+  @spec decode(<<_::16>>) :: ADS1015.Config.t()
+  def decode(bytes) when is_binary(bytes) do
+    <<performing_conversion::size(1), mux::size(3), gain::size(3), mode::size(1),
+      data_rate::size(3), comp_mode::size(1), comp_polarity::size(1), comp_latch::size(1),
+      comp_queue::size(2)>> = bytes
+
+    %__MODULE__{
+      performing_conversion: performing_conversion(performing_conversion),
+      mux: mux(mux),
+      gain: gain(gain),
+      mode: mode(mode),
+      data_rate: data_rate(data_rate),
+      comp_mode: comp_mode(comp_mode),
+      comp_polarity: comp_polarity(comp_polarity),
+      comp_latch: comp_latch(comp_latch),
+      comp_queue: comp_queue(comp_queue)
+    }
+  end
+
+  defp encode_performing_conversion(true), do: 0
+  defp encode_performing_conversion(false), do: 1
+  defp encode_mux({:ain0, :ain1}), do: 0      # default
+  defp encode_mux({:ain0, :ain3}), do: 1
+  defp encode_mux({:ain1, :ain3}), do: 2
+  defp encode_mux({:ain2, :ain3}), do: 3
+  defp encode_mux({:ain0, :gnd}), do: 4
+  defp encode_mux({:ain1, :gnd}), do: 5
+  defp encode_mux({:ain2, :gnd}), do: 6
+  defp encode_mux({:ain3, :gnd}), do: 7
+  defp encode_gain(6144), do: 0
+  defp encode_gain(4096), do: 1
+  defp encode_gain(2048), do: 2  # default
+  defp encode_gain(1024), do: 3
+  defp encode_gain(512), do: 4
+  defp encode_gain(256), do: 5  # 6 and 7 map to same gain
+  defp encode_mode(:continuous), do: 0
+  defp encode_mode(:single_shot), do: 1
+  defp encode_data_rate(128), do: 0
+  defp encode_data_rate(250), do: 1
+  defp encode_data_rate(490), do: 2
+  defp encode_data_rate(920), do: 3
+  defp encode_data_rate(1600), do: 4  #default
+  defp encode_data_rate(2400), do: 5
+  defp encode_data_rate(3300), do: 6  # 7 maps to same data rate
+  defp encode_comp_mode(:traditional), do: 0
+  defp encode_comp_mode(:window), do: 1
+  defp encode_comp_polarity(:active_low), do: 0
+  defp encode_comp_polarity(:active_high), do: 1
+  defp encode_comp_latch(false), do: 0
+  defp encode_comp_latch(true), do: 1
+  defp encode_comp_queue(1), do: 0
+  defp encode_comp_queue(2), do: 1
+  defp encode_comp_queue(3), do: 2
+  defp encode_comp_queue(:disabled), do: 3
+
+  defp performing_conversion(bit), do: bit == 0
+  defp mux(0), do: {:ain0, :ain1}
+  defp mux(1), do: {:ain0, :ain3}
+  defp mux(2), do: {:ain1, :ain3}
+  defp mux(3), do: {:ain2, :ain3}
+  defp mux(4), do: {:ain0, :gnd}
+  defp mux(5), do: {:ain1, :gnd}
+  defp mux(6), do: {:ain2, :gnd}
+  defp mux(7), do: {:ain3, :gnd}
+  defp gain(0), do: 6144
+  defp gain(1), do: 4096
+  defp gain(2), do: 2048
+  defp gain(3), do: 1024
+  defp gain(4), do: 512
+  defp gain(5), do: 256
+  defp gain(6), do: 256
+  defp gain(7), do: 256
+  defp mode(0), do: :continuous
+  defp mode(1), do: :single_shot
+  defp data_rate(0), do: 128
+  defp data_rate(1), do: 250
+  defp data_rate(2), do: 490
+  defp data_rate(3), do: 920
+  defp data_rate(4), do: 1600
+  defp data_rate(5), do: 2400
+  defp data_rate(6), do: 3300
+  defp data_rate(7), do: 3300
+  defp comp_mode(0), do: :traditional
+  defp comp_mode(1), do: :window
+  defp comp_polarity(0), do: :active_low
+  defp comp_polarity(1), do: :active_high
+  defp comp_latch(0), do: false
+  defp comp_latch(1), do: true
+  defp comp_queue(0), do: 1
+  defp comp_queue(1), do: 2
+  defp comp_queue(2), do: 3
+  defp comp_queue(3), do: :disabled
+end

--- a/lib/ads1015/config.ex
+++ b/lib/ads1015/config.ex
@@ -1,11 +1,11 @@
 defmodule ADS1015.Config do
   @moduledoc """
-  A struct representing the configuration of an ADS1115 chip.
+  A struct representing the configuration of an ADS1015 chip.
 
   This module handles decoding the 2-byte binary representation of the register
   into a struct and also encoding a struct back into the 2-byte binary representation.
   For details about what the various configuration options mean, please see
-  [the datasheet](http://www.ti.com/lit/gpn/ads1115).
+  [the datasheet](http://www.ti.com/lit/gpn/ads1015).
   """
 
   @type comp_mode :: :traditional | :window

--- a/test/ads1015_test.exs
+++ b/test/ads1015_test.exs
@@ -1,0 +1,54 @@
+defmodule ADS1015Test do
+  use ExUnit.Case, async: true
+
+  describe "config register decoding" do
+    test "default config state" do
+      assert %ADS1015.Config{} = config = ADS1015.Config.decode(<<133, 131>>)
+      assert config.performing_conversion == false
+      assert config.mux == {:ain0, :ain1}
+      assert config.gain == 2048
+      assert config.mode == :single_shot
+      assert config.data_rate == 1600
+      assert config.comp_mode == :traditional
+      assert config.comp_polarity == :active_low
+      assert config.comp_latch == false
+      assert config.comp_queue == :disabled
+    end
+
+    test "comparing AIN0 vs GND" do
+      assert %ADS1015.Config{} = config = ADS1015.Config.decode(<<197, 131>>)
+      assert config.performing_conversion == false
+      assert config.mux == {:ain0, :gnd}
+      assert config.gain == 2048
+      assert config.mode == :single_shot
+      assert config.data_rate == 1600
+      assert config.comp_mode == :traditional
+      assert config.comp_polarity == :active_low
+      assert config.comp_latch == false
+      assert config.comp_queue == :disabled
+    end
+  end
+
+  describe "config register encoding" do
+    test "default config" do
+      config = %ADS1015.Config{}
+      assert ADS1015.Config.encode(config) == <<133, 131>>
+    end
+
+    test "custom config" do
+      config = %ADS1015.Config{
+        performing_conversion: false,
+        mux: {:ain0, :gnd},
+        gain: 2048,
+        mode: :single_shot,
+        data_rate: 1600,
+        comp_mode: :traditional,
+        comp_polarity: :active_low,
+        comp_latch: false,
+        comp_queue: :disabled
+      }
+
+      assert ADS1015.Config.encode(config) == <<197, 131>>
+    end
+  end
+end


### PR DESCRIPTION
There's a lot of common code between ads1015, but I created a separate module and config just to be consistent. Probably might make sense to merge common config. I'm using the custom_read part in our product and it's giving correct values. Additional testing would be good! :) Resolves #1